### PR TITLE
feat(ReviewDB): use TableRow components instead of the older Form components

### DIFF
--- a/plugins/ReviewDB/src/Settings.tsx
+++ b/plugins/ReviewDB/src/Settings.tsx
@@ -1,42 +1,58 @@
-import { ReactNative as RN } from "@vendetta/metro/common";
+import { React } from "@vendetta/metro/common";
 import { useProxy } from "@vendetta/storage";
 import { storage } from "@vendetta/plugin";
 import { getAssetIDByName } from "@vendetta/ui/assets";
-import { Forms } from "@vendetta/ui/components";
 import showAuthModal from "./lib/showAuthModal";
+import { findByProps } from "@vendetta/metro";
 
-const { FormSection, FormRow, FormSwitchRow, FormDivider } = Forms;
+const { TableRow, TableSwitchRow, TableRowGroup } = findByProps("TableRow");
+const { Stack } = findByProps("Stack");
 
 export default () => {
     useProxy(storage);
 
+    const isAuthenticated = storage.authToken.length !== 0;
+
     return (
-        <RN.ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingBottom: 38 }}>
-            <FormSection title="Authentication" titleStyleType="no_border">
-                <FormRow
+        <Stack
+            style={{ paddingVertical: 24, paddingHorizontal: 12 }}
+            spacing={24}
+        >
+            <TableRowGroup title="Authentication">
+                <TableRow
                     label="Authenticate with ReviewDB"
-                    leading={<FormRow.Icon source={getAssetIDByName("copy")} />}
-                    trailing={FormRow.Arrow}
+                    icon={<TableRow.Icon source={getAssetIDByName("copy")} />}
+                    arrow={true}
+                    disabled={isAuthenticated}
                     onPress={showAuthModal}
                 />
-                <FormDivider />
-                <FormRow
+                <TableRow
+                    variant={isAuthenticated ? "danger" : undefined}
                     label="Log out of ReviewDB"
                     subLabel="Note that this does not remove ReviewDB from your Authorized Apps page in Discord."
-                    leading={<FormRow.Icon source={getAssetIDByName("ic_logout_24px")} />}
-                    disabled={storage.authToken.length === 0}
-                    onPress={() => storage.authToken = ""}
+                    icon={
+                        <TableRow.Icon
+                            variant={isAuthenticated ? "danger" : undefined}
+                            source={getAssetIDByName("ic_leave_24px")}
+                        />
+                    }
+                    disabled={!isAuthenticated}
+                    onPress={() => (storage.authToken = "")}
                 />
-            </FormSection>
-            <FormSection title="Settings">
-                <FormSwitchRow
+            </TableRowGroup>
+            <TableRowGroup title="Settings">
+                <TableSwitchRow
                     label="Use profile-themed send button"
                     subLabel="Controls whether the review send button should attempt to match the user's profile colors."
-                    leading={<FormRow.Icon source={getAssetIDByName("ic_paint_brush")} />}
+                    icon={
+                        <TableRow.Icon
+                            source={getAssetIDByName("ic_paint_brush")}
+                        />
+                    }
                     value={storage.useThemedSend}
-                    onValueChange={(v: boolean) => storage.useThemedSend = v}
+                    onValueChange={(v: boolean) => (storage.useThemedSend = v)}
                 />
-            </FormSection>
-        </RN.ScrollView>
-    )
-}
+            </TableRowGroup>
+        </Stack>
+    );
+};

--- a/plugins/ReviewDB/src/lib/showAuthModal.ts
+++ b/plugins/ReviewDB/src/lib/showAuthModal.ts
@@ -3,47 +3,58 @@ import { storage } from "@vendetta/plugin";
 import { logger } from "@vendetta";
 import { CLIENT_ID, API_URL } from "./constants";
 import { jsonFetch } from "./utils";
+import { showToast } from "@vendetta/ui/toasts";
+import { getAssetIDByName } from "@vendetta/ui/assets";
 
 const { pushModal, popModal } = findByProps("pushModal");
 const OAuth2AuthorizeModal = findByName("OAuth2AuthorizeModal");
 
 // Thank you to Fiery for figuring out the base for this
 // Some inspiration taken from https://github.com/Vendicated/Vencord/blob/77c691651e72ba1569666d560f96af04bfde9a4e/src/plugins/reviewDB/Utils/Utils.tsx#L39-L73
-export default () => pushModal({
-    key: "oauth2-authorize",
-    modal: {
+export default () =>
+    pushModal({
         key: "oauth2-authorize",
-        modal: OAuth2AuthorizeModal,
-        animation: "slide-up",
-        shouldPersistUnderModals: false,
-        props: {
-            clientId: CLIENT_ID,
-            redirectUri: API_URL + "/auth",
-            scopes: ["identify"],
-            responseType: "code",
-            permissions: 0n,
-            cancelCompletesFlow: false,
-            callback: async ({ location }) => {
-                try {
-                    const url = new URL(location);
-                    url.searchParams.append("returnType", "json");
-                    url.searchParams.append("clientMod", "vendetta");
+        modal: {
+            key: "oauth2-authorize",
+            modal: OAuth2AuthorizeModal,
+            animation: "slide-up",
+            shouldPersistUnderModals: false,
+            props: {
+                clientId: CLIENT_ID,
+                redirectUri: API_URL + "/auth",
+                scopes: ["identify"],
+                responseType: "code",
+                permissions: 0n,
+                cancelCompletesFlow: false,
+                callback: async ({ location }) => {
+                    try {
+                        const url = new URL(location);
+                        url.searchParams.append("returnType", "json");
+                        url.searchParams.append("clientMod", "vendetta");
 
-                    const { token, success, message } = await jsonFetch(url, { headers: { accept: "application/json" } });
+                        const { token, success, message } = await jsonFetch(
+                            url,
+                            { headers: { accept: "application/json" } },
+                        );
 
-                    if (success) {
-                        storage.authToken = token;
-                    } else {
-                        popModal("oauth2-authorize");
-                        throw new Error(message);
+                        if (success) {
+                            storage.authToken = token;
+                        } else {
+                            popModal("oauth2-authorize");
+                            throw new Error(message);
+                        }
+                    } catch (e) {
+                        // Helps with debugging.
+                        showToast(
+                            "Authorization failed! Try again later.",
+                            getAssetIDByName("CircleErrorIcon"),
+                        );
+
+                        logger.error("Authorization failed!", e);
                     }
-                } catch(e) {
-                    // TODO: Do we need a toast?
-                    logger.error("Authorization failed!", e);
-                }
+                },
+                dismissOAuthModal: () => popModal("oauth2-authorize"),
             },
-            dismissOAuthModal: () => popModal("oauth2-authorize"),
+            closable: true,
         },
-        closable: true,
-    },
-});
+    });


### PR DESCRIPTION
I thought TableRow components looked better than the old Forms based components, so I switched it to that.
I also made the authenticate button disabled when already authenticated, changed the colour of the log out text to red, fixed the icon and added a toast when the authorisation fails.
VSCode decided to format some code too.

|Forms|TableRow|
|---|---|
|<img width="283" height="550" alt="old" src="https://github.com/user-attachments/assets/930cf1d0-a2ef-4a2a-9a2d-6102c875913e" />|<img width="283" height="550" alt="new" src="https://github.com/user-attachments/assets/6d714d77-1a67-472b-8d86-e6617fb68700" />|

